### PR TITLE
cancel by taping fixed for grouped actions

### DIFF
--- a/RMActionController/RMActionController.m
+++ b/RMActionController/RMActionController.m
@@ -559,7 +559,8 @@ typedef NS_ENUM(NSInteger, RMActionControllerAnimationStyle) {
 }
 
 - (void)handleCancelNotAssociatedWithAnyButton {
-    for(RMAction *anAction in self.cancelActions) {
+    // Grouped Actions are stored in the doneActions array, so we'll need to check them as well
+    for(RMAction *anAction in [self.cancelActions arrayByAddingObjectsFromArray:self.doneActions]) {
         if([anAction containsCancelAction]) {
             [anAction executeHandlerOfCancelActionWithController:self];
             return;


### PR DESCRIPTION
If you init the control with “Select” and “Cancel” the actions are stored in the doneActions array, which is not check when taping outside the control.

```Objective-C
+ (instancetype)actionControllerWithStyle:(RMActionControllerStyle)style title:(NSString *)aTitle message:(NSString *)aMessage selectAction:(RMAction *)selectAction andCancelAction:(RMAction *)cancelAction {
    ...
    if(selectAction && cancelAction) {
        RMGroupedAction *action = [RMGroupedAction actionWithStyle:RMActionStyleDefault andActions:@[cancelAction, selectAction]];
        [controller addAction:action];
    ...
}
```