### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#Change Log
+# Change Log
 
 All notable changes to this project will be documented in this file.
 RMActionController adheres to [Semantic Versioning](http://semver.org/).

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Using this control in your app or know anyone who does?
 
 Feel free to add the app to this list: [Apps using RMActionController](https://github.com/CooperRS/RMActionController/wiki/Apps-using-RMActionController)
 
-##Credits
+## Credits
 
 * Hannes Tribus (Bugfixes)
 * normKei (Destructive button type)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
