### PR TITLE
Allow showing actions with title in tint color

### DIFF
--- a/RMActionController-Demo/Base.lproj/Main.storyboard
+++ b/RMActionController-Demo/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="udc-zS-aSN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="17A360a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="udc-zS-aSN">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -172,8 +172,8 @@ If your need a black version on iOS 7, take a look at the demo code.</string>
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blur Effects" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cgj-0D-7YY">
-                                                    <rect key="frame" x="15" y="11" width="89" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blur Effects (All)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cgj-0D-7YY">
+                                                    <rect key="frame" x="15" y="11" width="123" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -191,8 +191,34 @@ If your need a black version on iOS 7, take a look at the demo code.</string>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="0uf-pB-Z3a">
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="LIq-7a-1wo">
                                         <rect key="frame" x="0.0" y="474.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="LIq-7a-1wo" id="Fmy-69-nha">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blur Effects (Actions)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ioj-rf-WU2">
+                                                    <rect key="frame" x="15" y="11" width="162" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tQU-bn-19S">
+                                                    <rect key="frame" x="311" y="6" width="51" height="31"/>
+                                                    <accessibility key="accessibilityConfiguration" label="BouncingEffects"/>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="tQU-bn-19S" secondAttribute="trailing" constant="15" id="Cwv-cG-nXg"/>
+                                                <constraint firstAttribute="centerY" secondItem="tQU-bn-19S" secondAttribute="centerY" id="RNH-K5-YkD"/>
+                                                <constraint firstItem="ioj-rf-WU2" firstAttribute="leading" secondItem="Fmy-69-nha" secondAttribute="leading" constant="15" id="opM-1S-WlA"/>
+                                                <constraint firstAttribute="centerY" secondItem="ioj-rf-WU2" secondAttribute="centerY" id="yG2-B4-kac"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="0uf-pB-Z3a">
+                                        <rect key="frame" x="0.0" y="518.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="0uf-pB-Z3a" id="VZE-Iw-VdN">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -218,7 +244,7 @@ If your need a black version on iOS 7, take a look at the demo code.</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="Lo2-u3-HQv">
-                                        <rect key="frame" x="0.0" y="518.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="562.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Lo2-u3-HQv" id="tkF-xY-4o6">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -248,7 +274,7 @@ If your need a black version on iOS 7, take a look at the demo code.</string>
                             <tableViewSection headerTitle="" id="LXP-f0-YuE">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="y4b-Bl-Pvu" detailTextLabel="VYV-y8-Gzj" style="IBUITableViewCellStyleValue1" id="ZuU-OY-2Xu">
-                                        <rect key="frame" x="0.0" y="602.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="646.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ZuU-OY-2Xu" id="GlE-bI-kWK">
                                             <rect key="frame" x="0.0" y="0.0" width="342" height="43.5"/>
@@ -281,6 +307,7 @@ If your need a black version on iOS 7, take a look at the demo code.</string>
                     <navigationItem key="navigationItem" title="Objective-C Demo" id="I0k-is-Syx"/>
                     <connections>
                         <outlet property="blackSwitch" destination="zIP-i2-iGI" id="M7G-FS-hV9"/>
+                        <outlet property="blurActionsSwitch" destination="tQU-bn-19S" id="prj-jR-HrL"/>
                         <outlet property="blurSwitch" destination="IYE-EG-ZeU" id="Wvn-eY-O7O"/>
                         <outlet property="bouncingSwitch" destination="t4u-2y-gb7" id="YxY-GX-lwT"/>
                         <outlet property="motionSwitch" destination="DHP-vc-zbb" id="Ou1-rW-7ha"/>

--- a/RMActionController-Demo/RMViewController.m
+++ b/RMActionController-Demo/RMViewController.m
@@ -33,6 +33,7 @@
 
 @property (nonatomic, weak) IBOutlet UISwitch *blackSwitch;
 @property (nonatomic, weak) IBOutlet UISwitch *blurSwitch;
+@property (nonatomic, weak) IBOutlet UISwitch *blurActionsSwitch;
 @property (nonatomic, weak) IBOutlet UISwitch *motionSwitch;
 @property (nonatomic, weak) IBOutlet UISwitch *bouncingSwitch;
 
@@ -145,6 +146,7 @@
     actionController.disableBouncingEffects = !self.bouncingSwitch.on;
     actionController.disableMotionEffects = !self.motionSwitch.on;
     actionController.disableBlurEffects = !self.blurSwitch.on;
+    actionController.disableBlurEffectsForActions = !self.blurActionsSwitch.on;
     
     //On the iPad we want to show the map action controller within a popover. Fortunately, we can use iOS 8 API for this! :)
     //(Of course only if we are running on iOS 8 or later)

--- a/RMActionController-SwiftDemo/Base.lproj/Main.storyboard
+++ b/RMActionController-SwiftDemo/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="r39-Ph-vqF">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="17A360a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="r39-Ph-vqF">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -172,8 +172,8 @@ If your need a black version on iOS 7, take a look at the demo code.</string>
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blur Effects" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dXF-ax-6qD">
-                                                    <rect key="frame" x="15" y="11.5" width="88.5" height="20.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blur Effects (All)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dXF-ax-6qD">
+                                                    <rect key="frame" x="15" y="11.5" width="123" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -191,8 +191,34 @@ If your need a black version on iOS 7, take a look at the demo code.</string>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="bXP-8z-zJp">
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="jze-9f-2sr">
                                         <rect key="frame" x="0.0" y="474.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="jze-9f-2sr" id="nkz-wh-pPz">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blur Effects (Actions)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kMo-RX-i2D">
+                                                    <rect key="frame" x="15" y="11.5" width="162" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0aq-sx-f3s">
+                                                    <rect key="frame" x="311" y="6.5" width="51" height="31"/>
+                                                    <accessibility key="accessibilityConfiguration" label="BouncingEffects"/>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="centerY" secondItem="kMo-RX-i2D" secondAttribute="centerY" id="22G-ms-HvQ"/>
+                                                <constraint firstAttribute="centerY" secondItem="0aq-sx-f3s" secondAttribute="centerY" id="Rjs-qG-5jE"/>
+                                                <constraint firstItem="kMo-RX-i2D" firstAttribute="leading" secondItem="nkz-wh-pPz" secondAttribute="leading" constant="15" id="cnF-qR-j1P"/>
+                                                <constraint firstAttribute="trailing" secondItem="0aq-sx-f3s" secondAttribute="trailing" constant="15" id="f0A-5V-RkF"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="bXP-8z-zJp">
+                                        <rect key="frame" x="0.0" y="518.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="bXP-8z-zJp" id="A8Y-K6-mn4">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -218,7 +244,7 @@ If your need a black version on iOS 7, take a look at the demo code.</string>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="zzT-dZ-BJf">
-                                        <rect key="frame" x="0.0" y="518.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="562.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zzT-dZ-BJf" id="q3Q-lX-e0F">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -248,7 +274,7 @@ If your need a black version on iOS 7, take a look at the demo code.</string>
                             <tableViewSection headerTitle="" id="t8I-V1-dyJ">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="TNH-9E-d3x" detailTextLabel="Ewj-J4-cA7" style="IBUITableViewCellStyleValue1" id="TH8-jJ-twm">
-                                        <rect key="frame" x="0.0" y="602.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="646.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="TH8-jJ-twm" id="oJk-Gr-2aK">
                                             <rect key="frame" x="0.0" y="0.0" width="342" height="43.5"/>
@@ -281,6 +307,7 @@ If your need a black version on iOS 7, take a look at the demo code.</string>
                     <navigationItem key="navigationItem" title="Swift Demo" id="3rD-Tk-zCd"/>
                     <connections>
                         <outlet property="blackSwitch" destination="TCg-Pw-39K" id="IiN-aD-USc"/>
+                        <outlet property="blurActionSwitch" destination="0aq-sx-f3s" id="EVV-CH-Fb4"/>
                         <outlet property="blurSwitch" destination="1n8-vX-pAN" id="9Og-sE-Oxi"/>
                         <outlet property="bouncingSwitch" destination="90i-Mw-waL" id="8CV-na-xnc"/>
                         <outlet property="motionSwitch" destination="L4I-NB-f8k" id="cn3-9x-aJM"/>

--- a/RMActionController-SwiftDemo/ViewController.swift
+++ b/RMActionController-SwiftDemo/ViewController.swift
@@ -15,6 +15,7 @@ class ViewController: UITableViewController {
     //MARK: Properties
     @IBOutlet weak var blackSwitch: UISwitch!
     @IBOutlet weak var blurSwitch: UISwitch!
+    @IBOutlet weak var blurActionSwitch: UISwitch!
     @IBOutlet weak var motionSwitch: UISwitch!
     @IBOutlet weak var bouncingSwitch: UISwitch!
     
@@ -122,6 +123,7 @@ class ViewController: UITableViewController {
         actionController.disableBouncingEffects = !self.bouncingSwitch.isOn
         actionController.disableMotionEffects = !self.motionSwitch.isOn
         actionController.disableBlurEffects = !self.blurSwitch.isOn
+        actionController.disableBlurEffectsForActions = !self.blurActionSwitch.isOn
         
         //On the iPad we want to show the date selection view controller within a popover. Fortunately, we can use iOS 8 API for this! :)
         //(Of course only if we are running on iOS 8 or later)

--- a/RMActionController/Actions/RMAction.m
+++ b/RMActionController/Actions/RMAction.m
@@ -112,7 +112,7 @@
 
 - (UIView *)loadView {
     UIButtonType buttonType = UIButtonTypeCustom;
-    if(self.controller.disableBlurEffects) {
+    if(self.controller.disableBlurEffectsForActions) {
         buttonType = UIButtonTypeSystem;
     }
     
@@ -125,17 +125,17 @@
         actionButton.titleLabel.font = [UIFont systemFontOfSize:[UIFont buttonFontSize]];
     }
     
-    if(!self.controller.disableBlurEffects) {
+    if(!self.controller.disableBlurEffectsForActions) {
         [actionButton setBackgroundImage:[self imageWithColor:[[UIColor whiteColor] colorWithAlphaComponent:0.3]] forState:UIControlStateHighlighted];
     } else {
         switch (self.controller.style) {
             case RMActionControllerStyleWhite:
             case RMActionControllerStyleSheetWhite:
-                [actionButton setBackgroundImage:[self imageWithColor:[UIColor colorWithWhite:230./255. alpha:1]] forState:UIControlStateHighlighted];
+                [actionButton setBackgroundImage:[self imageWithColor:[UIColor colorWithWhite:0.2 alpha:1]] forState:UIControlStateHighlighted];
                 break;
             case RMActionControllerStyleBlack:
             case RMActionControllerStyleSheetBlack:
-                [actionButton setBackgroundImage:[self imageWithColor:[UIColor colorWithWhite:0.2 alpha:1]] forState:UIControlStateHighlighted];
+                [actionButton setBackgroundImage:[self imageWithColor:[UIColor colorWithWhite:0.8 alpha:1]] forState:UIControlStateHighlighted];
                 break;
         }
     }

--- a/RMActionController/RMActionController.h
+++ b/RMActionController/RMActionController.h
@@ -193,4 +193,13 @@ typedef NS_ENUM(NSInteger, RMActionControllerStyle) {
  */
 @property (assign, nonatomic) BOOL disableBlurEffectsForBackgroundView;
 
+/**
+ *  Used to enable or disable blurring actions. If you want the title of your action to appear in your tint color, set this to YES. Same for image actions: If the image should appear in its original colors, set this to YES. Otherwise NO.
+ *
+ *  The default value is NO.
+ *
+ *  @warning This property always returns YES, if disableBlurEffects returns YES.
+ */
+@property (assign, nonatomic) BOOL disableBlurEffectsForActions;
+
 @end

--- a/RMActionController/RMActionController.m
+++ b/RMActionController/RMActionController.m
@@ -200,11 +200,13 @@
     }
     
     for(RMAction *anAction in self.additionalActions) {
-        [viewForAddingSubviews addSubview:anAction.view];
+        UIView *view = self.disableBlurEffectsForActions ? self.topContainer : viewForAddingSubviews;
+        [view addSubview:anAction.view];
     }
     
     for(RMAction *anAction in self.doneActions) {
-        [viewForAddingSubviews addSubview:anAction.view];
+        UIView *view = self.disableBlurEffectsForActions ? self.topContainer : viewForAddingSubviews;
+        [view addSubview:anAction.view];
     }
     
     //Container properties
@@ -244,7 +246,8 @@
     }
     
     for(RMAction *anAction in self.cancelActions) {
-        [viewForAddingSubviews addSubview:anAction.view];
+        UIView *view = self.disableBlurEffectsForActions ? self.bottomContainer : viewForAddingSubviews;
+        [view addSubview:anAction.view];
     }
     
     //Container properties
@@ -588,6 +591,14 @@
     }
     
     return _disableBlurEffectsForContentView;
+}
+
+- (BOOL)disableBlurEffectsForActions {
+    if(self.disableBlurEffects) {
+        return YES;
+    }
+    
+    return _disableBlurEffectsForActions;
 }
 
 - (BOOL)disableBouncingEffects {

--- a/RMActionController/RMActionController.m
+++ b/RMActionController/RMActionController.m
@@ -162,86 +162,49 @@
 }
 
 - (void)setupContainerElements {
-    //Top container
+    [self setupTopContainerElements];
+    [self setupBottomContainerElements];
+}
+
+- (void)setupTopContainerElements {
+    UIView *viewForAddingSubviews = nil;
     if(self.disableBlurEffects) {
         self.topContainer = [[UIView alloc] initWithFrame:CGRectZero];
-        
-        [self.topContainer addSubview:self.contentView];
-        
-        if([self.headerTitleLabel.text length] > 0) {
-            [self.topContainer addSubview:self.headerTitleLabel];
-        }
-        
-        if([self.headerMessageLabel.text length] > 0) {
-            [self.topContainer addSubview:self.headerMessageLabel];
-        }
-        
-        for(RMAction *anAction in self.additionalActions) {
-            [self.topContainer addSubview:anAction.view];
-        }
-        
-        for(RMAction *anAction in self.doneActions) {
-            [self.topContainer addSubview:anAction.view];
-        }
+        viewForAddingSubviews = self.topContainer;
     } else {
         UIBlurEffect *blur = [UIBlurEffect effectWithStyle:[self containerBlurEffectStyleForCurrentStyle]];
         UIVibrancyEffect *vibrancy = [UIVibrancyEffect effectForBlurEffect:blur];
         
         UIVisualEffectView *vibrancyView = [[UIVisualEffectView alloc] initWithEffect:vibrancy];
         vibrancyView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-        
-        if(!self.disableBlurEffectsForContentView) {
-            [vibrancyView.contentView addSubview:self.contentView];
-        }
-        
-        if([self.headerTitleLabel.text length] > 0) {
-            [vibrancyView.contentView addSubview:self.headerTitleLabel];
-        }
-        
-        if([self.headerMessageLabel.text length] > 0) {
-            [vibrancyView.contentView addSubview:self.headerMessageLabel];
-        }
-        
-        for(RMAction *anAction in self.additionalActions) {
-            [vibrancyView.contentView addSubview:anAction.view];
-        }
-        
-        for(RMAction *anAction in self.doneActions) {
-            [vibrancyView.contentView addSubview:anAction.view];
-        }
         
         UIVisualEffectView *container = [[UIVisualEffectView alloc] initWithEffect:blur];
         [container.contentView addSubview:vibrancyView];
         
         self.topContainer = container;
-        
-        if(self.disableBlurEffectsForContentView) {
-            [self.topContainer addSubview:self.contentView];
-        }
+        viewForAddingSubviews = vibrancyView.contentView;
     }
     
-    //Botoom container
-    if(self.disableBlurEffects) {
-        self.bottomContainer = [[UIView alloc] initWithFrame:CGRectZero];
-        
-        for(RMAction *anAction in self.cancelActions) {
-            [self.bottomContainer addSubview:anAction.view];
-        }
+    if(!self.disableBlurEffectsForContentView) {
+        [viewForAddingSubviews addSubview:self.contentView];
     } else {
-        UIBlurEffect *blur = [UIBlurEffect effectWithStyle:[self containerBlurEffectStyleForCurrentStyle]];
-        UIVibrancyEffect *vibrancy = [UIVibrancyEffect effectForBlurEffect:blur];
-        
-        UIVisualEffectView *vibrancyView = [[UIVisualEffectView alloc] initWithEffect:vibrancy];
-        vibrancyView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-        
-        for(RMAction *anAction in self.cancelActions) {
-            [vibrancyView.contentView addSubview:anAction.view];
-        }
-        
-        UIVisualEffectView *container = [[UIVisualEffectView alloc] initWithEffect:blur];
-        [container.contentView addSubview:vibrancyView];
-        
-        self.bottomContainer = container;
+        [self.topContainer addSubview:self.contentView];
+    }
+    
+    if([self.headerTitleLabel.text length] > 0) {
+        [viewForAddingSubviews addSubview:self.headerTitleLabel];
+    }
+    
+    if([self.headerMessageLabel.text length] > 0) {
+        [viewForAddingSubviews addSubview:self.headerMessageLabel];
+    }
+    
+    for(RMAction *anAction in self.additionalActions) {
+        [viewForAddingSubviews addSubview:anAction.view];
+    }
+    
+    for(RMAction *anAction in self.doneActions) {
+        [viewForAddingSubviews addSubview:anAction.view];
     }
     
     //Container properties
@@ -255,6 +218,36 @@
         self.topContainer.backgroundColor = [UIColor whiteColor];
     }
     
+    //Debugging Accessibility Labels
+#ifdef DEBUG
+    self.topContainer.accessibilityLabel = @"TopContainer";
+#endif
+}
+
+- (void)setupBottomContainerElements {
+    UIView *viewForAddingSubviews = nil;
+    if(self.disableBlurEffects) {
+        self.bottomContainer = [[UIView alloc] initWithFrame:CGRectZero];
+        viewForAddingSubviews = self.bottomContainer;
+    } else {
+        UIBlurEffect *blur = [UIBlurEffect effectWithStyle:[self containerBlurEffectStyleForCurrentStyle]];
+        UIVibrancyEffect *vibrancy = [UIVibrancyEffect effectForBlurEffect:blur];
+        
+        UIVisualEffectView *vibrancyView = [[UIVisualEffectView alloc] initWithEffect:vibrancy];
+        vibrancyView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        
+        UIVisualEffectView *container = [[UIVisualEffectView alloc] initWithEffect:blur];
+        [container.contentView addSubview:vibrancyView];
+        
+        self.bottomContainer = container;
+        viewForAddingSubviews = vibrancyView.contentView;
+    }
+    
+    for(RMAction *anAction in self.cancelActions) {
+        [viewForAddingSubviews addSubview:anAction.view];
+    }
+    
+    //Container properties
     self.bottomContainer.layer.cornerRadius = [self cornerRadiusForCurrentStyle];
     self.bottomContainer.clipsToBounds = YES;
     self.bottomContainer.translatesAutoresizingMaskIntoConstraints = NO;
@@ -267,7 +260,6 @@
     
     //Debugging Accessibility Labels
 #ifdef DEBUG
-    self.topContainer.accessibilityLabel = @"TopContainer";
     self.bottomContainer.accessibilityLabel = @"BottomContainer";
 #endif
 }


### PR DESCRIPTION
This PR introduces new new Property `RMActionController.disableBlurEffectsForActions`. Set it to `YES` to achieve the appearance below.

| White | Black |
|:---:|:---:|
| ![simulator screen shot 09 09 2017 13 29 43](https://user-images.githubusercontent.com/342095/30239727-f923ed3c-9562-11e7-8bbb-efad00962661.png) | ![simulator screen shot 09 09 2017 13 29 48](https://user-images.githubusercontent.com/342095/30239726-f923307c-9562-11e7-80f0-f977bf2965a4.png) |
