### PR TITLE
Disable blur effects for background by default

### DIFF
--- a/RMActionController/RMActionController.h
+++ b/RMActionController/RMActionController.h
@@ -189,6 +189,8 @@ typedef NS_ENUM(NSInteger, RMActionControllerStyle) {
 /**
  *  Used to enable or disable blurring the background of RMActionController.
  *
+ *  The default value is YES.
+ *
  *  @warning This property always returns YES, if disableBlurEffects returns YES.
  */
 @property (assign, nonatomic) BOOL disableBlurEffectsForBackgroundView;

--- a/RMActionController/RMActionController.m
+++ b/RMActionController/RMActionController.m
@@ -136,7 +136,8 @@
     }
     
     self.transitioningDelegate = self;
-    
+
+    self.disableBlurEffectsForBackgroundView = YES;
     [self setupUIElements];
 }
 


### PR DESCRIPTION
This PR disables blur effects for the background view by default. `RMActionController` now looks a bit more like default iOS sheets by default.